### PR TITLE
chore(release): 6.1.0

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -196,13 +196,13 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@master
         with:
           find: "https:\\/\\/github\\.com\\/plugsy\\/core\\/releases\\/download\\/(.*?)\\/core-config-schema\\.json"
-          replace: "https://github.com/plugsy/core/releases/download/v${{ needs.getversion.outputs.version }}/core-config-schema.json"
+          replace: "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json"
 
       - name: Find and Replace
         uses: jacobtomlinson/gha-find-replace@master
         with:
           find: "https:\\/\\/github\\.com\\/plugsy\\/core\\/releases\\/download\\/(.*?)\\/agent-config-schema\\.json"
-          replace: "https://github.com/plugsy/core/releases/download/v${{ needs.getversion.outputs.version }}/agent-config-schema.json"
+          replace: "https://github.com/plugsy/core/releases/download/v6.1.0/agent-config-schema.json"
 
       - name: Create Pull Request with updated package files
         uses: peter-evans/create-pull-request@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [6.1.0](https://github.com/plugsy/core/compare/v6.0.0...v6.1.0) (2021-11-29)
+
+
+### Features
+
+* Docker containers now show their health if they have it ([b407b28](https://github.com/plugsy/core/commit/b407b28b246651a23b7f9358ef89b3e99a24c90a))
+
 ## [6.0.0](https://github.com/plugsy/core/compare/v5.0.1...v6.0.0) (2021-08-11)
 
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ config.json
 
 ```jsonc
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/core-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json",
   "connectors": [
     {
       "type": "DOCKER",
@@ -218,7 +218,7 @@ Example using the [raw connector](docs/connectors/raw.md):
 
 ```jsonc
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/core-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json",
   "connectors": [
     {
       "type": "DOCKER",

--- a/docs/agent-mode.md
+++ b/docs/agent-mode.md
@@ -45,7 +45,7 @@ docker-compose.yml
 config.json
 ```json
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/agent-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/agent-config-schema.json",
   "agent": {
     "endpoint": "http://localhost:3000/graphql",
     "clientConfig": {
@@ -87,7 +87,7 @@ Simply add the agent section to your configuration file with the location of you
 
 ```jsonc
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/core-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json",
   "agent": {
     "endpoint": "http://localhost:3000/graphql"
   }

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -24,7 +24,7 @@ Can use a list of website urls (And other request formats) for Plugsy to ping an
 
 ```jsonc
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/core-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json",
   "connectors": [
     {
       "type": "DOCKER",

--- a/docs/connectors/docker.md
+++ b/docs/connectors/docker.md
@@ -6,7 +6,7 @@ A docker connector, provides access directly to a docker socket or URL mapping e
 
 ```jsonc
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/core-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json",
   "connectors": [
     {
       "type": "DOCKER",
@@ -95,7 +95,7 @@ services:
 
 ```jsonc
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/core-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json",
   "connectors": [
     {
       "type": "DOCKER",
@@ -130,7 +130,7 @@ See [Dockerode](https://www.npmjs.com/package/dockerode) for alternative connect
 
 ```jsonc
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/core-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json",
   "connectors": [
     {
       "type": "DOCKER",

--- a/docs/connectors/raw.md
+++ b/docs/connectors/raw.md
@@ -6,7 +6,7 @@ Provides items in the dashboard directly from the config itself
 
 ```jsonc
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/core-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json",
   "connectors": [
     {
       "type": "RAW",
@@ -28,7 +28,7 @@ Provides items in the dashboard directly from the config itself
 
 ```jsonc
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/core-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json",
   "connectors": [
     {
       "type": "RAW",

--- a/docs/connectors/website.md
+++ b/docs/connectors/website.md
@@ -8,7 +8,7 @@ Can use a list of website urls (And other request formats) for Plugsy to ping an
 
 ```jsonc
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/core-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json",
   "connectors": [
     {
       "type": "WEBSITE",
@@ -32,7 +32,7 @@ Can use a list of website urls (And other request formats) for Plugsy to ping an
 
 ```jsonc
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/core-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json",
   "connectors": [
     {
       "type": "WEBSITE",

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -20,7 +20,7 @@ Good for use on a TV
 
 ```jsonc
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/core-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json",
   "loggingLevel": "verbose",
   "theme": {
     "pages": {
@@ -46,7 +46,7 @@ This can be used as a base for a dark mode.
 
 ```jsonc
 {
-  "$schema": "https://github.com/plugsy/core/releases/download/v6.0.0/core-config-schema.json",
+  "$schema": "https://github.com/plugsy/core/releases/download/v6.1.0/core-config-schema.json",
   "theme": {
     "colors": {
       "GREEN": "#50fa7b",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "6.0.0",
+  "version": "6.1.0",
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
Version bump in package.json and yarn.lock for release [6.1.0](https://github.com/plugsy/core/releases/tag/v6.1.0)